### PR TITLE
Potential fix for code scanning alert no. 716: Reflected cross-site scripting

### DIFF
--- a/handler/htmx/htmx.go
+++ b/handler/htmx/htmx.go
@@ -46,7 +46,7 @@ func Areacodes(c echo.Context) error {
 	query := areacode.Queries(searches...)
 	if len(query) == 0 {
 		return c.HTML(http.StatusOK,
-			"<small>No results for '"+search+"'.</small><br>")
+			"<small>No results for '"+html.EscapeString(search)+"'.</small><br>")
 	}
 	for val := range slices.Values(query) {
 		if val.AreaCode.Valid() {

--- a/handler/htmx/htmx.go
+++ b/handler/htmx/htmx.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"html"
 	"html/template"
 	"net/http"
 	"slices"


### PR DESCRIPTION
Potential fix for [https://github.com/Defacto2/server/security/code-scanning/716](https://github.com/Defacto2/server/security/code-scanning/716)

To fix the issue, the user-provided input should be properly sanitized or escaped before being included in the HTML response. The Go `html/template` package provides the `html.EscapeString` function, which is designed to escape special HTML characters like `<`, `>`, `&`, and `"`. This ensures that any potentially malicious input is rendered as plain text instead of being interpreted as executable HTML or JavaScript.

- **General Fix:** Sanitize the `search` variable using `html.EscapeString` before concatenating it into the HTML response.
- **Implementation:** Replace the direct use of the `search` variable in line 49 with `html.EscapeString(search)`. This ensures that any special characters in the input are safely escaped.
- **Files/Regions Affected:** Modify the string concatenation logic on line 49 in `handler/htmx/htmx.go`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
